### PR TITLE
Added lastSearchTime field to the lidarr album structure

### DIFF
--- a/varken/structures.py
+++ b/varken/structures.py
@@ -668,6 +668,7 @@ class LidarrAlbum(NamedTuple):
     secondaryTypes: list = None
     statistics: dict = {}
     title: str = None
+    lastSearchTime: str = None
     
 #TODO - Lidarr support
 # Lidarr /api/v1/artist


### PR DESCRIPTION
Fixed issue where Varken is unable to process 'lastSearchTime' field ([issue](https://github.com/durganshtaneja/Varken/issues/1)) by adding 'lastSearchTime' field in the LidarrAlbum structure.